### PR TITLE
10x faster Geocoding, 60% less memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ pressure, it will attempt to start uncaching regions from the biggest currently
 cached one in order down to try to free memory.  If it doesn't work then it will
 throw an error.
 
-One good region to test memory usage with is nationwide zip codes: https://data.austintexas.gov/d/a3it-2a2z with ~34000 features.
+One good region to test memory usage with is nationwide zip codes: https://data.austintexas.gov/d/a3it-2a2z with ~34000 features.  Another one is: qz3q-ghft.
+
+NOTE: If you are doing memory testing locally on spatial caching, some hints:
+- Start SBT with something like `-Xmx8g -Xms8g` in `$SBT_OPTS`.  If -Xms is not equal to -Xmx, Geospace's memory detector doesn't work properly.
+- Use the `local-shp` route to load a local unpacked shape file dir into memory as cache:
+
+        curl -X POST "http://localhost:2020/v1/regions/census_orig/local-shp?forceLonLat=true" -d $HOME/data/census/orig/ -H "Content-Type: application/json"
 
 ## Optimizations
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pressure, it will attempt to start uncaching regions from the biggest currently
 cached one in order down to try to free memory.  If it doesn't work then it will
 throw an error.
 
-One good region to test memory usage with is nationwide zip codes: https://data.austintexas.gov/d/a3it-2a2z with ~34000 features.  Another one is: qz3q-ghft.
+One good region to test memory usage with is nationwide zip codes: https://data.austintexas.gov/d/a3it-2a2z with ~34000 features.  Another one is: qz3q-ghft.  These are all 4x4's in production.
 
 NOTE: If you are doing memory testing locally on spatial caching, some hints:
 - Start SBT with something like `-Xmx8g -Xms8g` in `$SBT_OPTS`.  If -Xms is not equal to -Xmx, Geospace's memory detector doesn't work properly.

--- a/src/main/scala/com/socrata/geospace/GeospaceServlet.scala
+++ b/src/main/scala/com/socrata/geospace/GeospaceServlet.scala
@@ -124,8 +124,10 @@ with FileUploadSupport with Metrics {
 
     // Cache the reprojected features in our region cache for immediate geocoding
     // TODO: what do we do if the region was previously cached already?  Need to invalidate cache
-    spatialCache.getFromFeatures(params("resourceName"), features.toSeq)
-    Map("rows-ingested" -> features.toSeq.length)
+    new AsyncResult { val is =
+      spatialCache.getFromFeatures(params("resourceName"), features.toSeq)
+        .map { index => Map("rows-ingested" -> features.toSeq.length) }
+    }
   }
 
   // NOTE: Tricky to find a good REST endpoint.  What is the resource?  geo-regions?

--- a/src/main/scala/com/socrata/geospace/regioncache/SpatialIndex.scala
+++ b/src/main/scala/com/socrata/geospace/regioncache/SpatialIndex.scala
@@ -3,9 +3,12 @@ package com.socrata.geospace.regioncache
 import com.socrata.geospace.feature.FeatureExtensions._
 import com.socrata.geospace.Utils._
 import com.typesafe.scalalogging.slf4j.Logging
-import com.vividsolutions.jts.geom.{Envelope, Geometry}
+import com.vividsolutions.jts.geom.impl.PackedCoordinateSequence
+import com.vividsolutions.jts.geom.prep.{PreparedGeometry, PreparedGeometryFactory}
+import com.vividsolutions.jts.geom.util.GeometryTransformer
+import com.vividsolutions.jts.geom.{Envelope, Geometry, CoordinateSequence}
 import com.vividsolutions.jts.index.strtree.STRtree
-import SpatialIndex.Entry
+import SpatialIndex._
 
 /**
  * A spatial index based on JTS STRTree.  It is immutable, once built, it cannot be changed.
@@ -18,6 +21,7 @@ import SpatialIndex.Entry
  * @param items A sequence of SpatialIndex.Entry's to index
  */
 class SpatialIndex[T](items: Seq[Entry[T]]) extends Logging {
+  logger.info(s"Created new SpatialIndex with ${items.length} items")
 
   private val index = new STRtree() // use default node capacity
 
@@ -34,7 +38,7 @@ class SpatialIndex[T](items: Seq[Entry[T]]) extends Logging {
    */
   def whatContains(geom: Geometry): Seq[Entry[T]] = {
     val results = index.query(geom.getEnvelopeInternal).asScala.asInstanceOf[Seq[Entry[T]]]
-    results.filter { entry => entry.geom.covers(geom) }
+    results.filter { entry => entry.prep.covers(geom) }
   }
 
   /**
@@ -45,14 +49,14 @@ class SpatialIndex[T](items: Seq[Entry[T]]) extends Logging {
    */
   def firstContains(geom: Geometry): Option[Entry[T]] = {
     val results = index.query(geom.getEnvelopeInternal).asScala.asInstanceOf[Seq[Entry[T]]]
-    results.find { entry => entry.geom.covers(geom) }
+    results.find { entry => entry.prep.covers(geom) }
   }
 
   private def addItems(): Int = {
 
     val numCoords = items.foldLeft(0) { (numCoords, entry) =>
-      index.insert(entry.geom.getEnvelopeInternal, entry)
-      numCoords + entry.geom.getCoordinates.size
+      index.insert(entry.envelope, entry)
+      numCoords + entry.numCoordinates
     }
     logger.info("Added {} items and {} coordinates to cache", items.size.toString, numCoords.toString)
     logMemoryUsage("After populating SpatialIndex")
@@ -60,11 +64,51 @@ class SpatialIndex[T](items: Seq[Entry[T]]) extends Logging {
   }
 }
 
+// Offers a really convenient way to convert Geometries to use ones with more compact or efficient
+// CoordinateSequences
+object GeometryConverter {
+  val transformer = new GeometryTransformer {
+    override def transformCoordinates(coordSeq: CoordinateSequence, parent: Geometry): CoordinateSequence = {
+      new PackedCoordinateSequence.Double(coordSeq.toCoordinateArray)
+    }
+  }
+}
+
 object SpatialIndex {
   import org.geoscript.layer._
   import org.geoscript.feature._
 
-  case class Entry[T](geom: Geometry, item: T)
+  trait Entry[T] {
+    def geom: Geometry
+    def item: T
+    def prep: PreparedGeometry
+    def envelope: Envelope
+    def numCoordinates: Int
+  }
+
+  case class GeoEntry[T](geom: Geometry, item: T) extends Entry[T] {
+    val prep = PreparedGeometryFactory.prepare(geom)
+    def envelope = geom.getEnvelopeInternal
+    def numCoordinates = geom.getCoordinates.size
+  }
+
+  object GeoEntry {
+    // Create a memory-efficient Geometry based on PackedCoordinateSequence, which stores
+    // coordinates as double arrays internally, and unpacks to Coordinate[] on demand using
+    // a soft-reference.  If there is GC pressure, soft references can be cleared.
+    def compact[T](geom: Geometry, item: T): GeoEntry[T] = {
+      val compactGeom = GeometryConverter.transformer.transform(geom)
+      val origEnvelope = geom.getEnvelopeInternal
+      val origNumCoords = geom.getCoordinates.size
+      // NOTE: store the envelope separately so that we don't have to force the compact
+      // coordinates to be unpacked.
+      // Also, don't capture the original geom objects
+      new GeoEntry(compactGeom, item) {
+        override val envelope = origEnvelope
+        override val numCoordinates = origNumCoords
+      }
+    }
+  }
 
   /**
    * Create a SpatialIndex[String] from a Layer/FeatureSource.  The feature ID will be stored in the index.
@@ -82,8 +126,8 @@ object SpatialIndex {
    */
   def apply(features: Seq[Feature]): SpatialIndex[Int] = {
     val items = features.map { feature =>
-        Entry(feature.getDefaultGeometry.asInstanceOf[Geometry], feature.numericId)
-      }
+      GeoEntry.compact(feature.getDefaultGeometry.asInstanceOf[Geometry], feature.numericId)
+    }
     new SpatialIndex(items.toSeq)
   }
 }

--- a/src/main/scala/com/socrata/geospace/regioncache/SpatialIndex.scala
+++ b/src/main/scala/com/socrata/geospace/regioncache/SpatialIndex.scala
@@ -21,7 +21,7 @@ import SpatialIndex._
  * @param items A sequence of SpatialIndex.Entry's to index
  */
 class SpatialIndex[T](items: Seq[Entry[T]]) extends Logging {
-  logger.info(s"Created new SpatialIndex with ${items.length} items")
+  logger.info(s"Creating new SpatialIndex with ${items.length} items")
 
   private val index = new STRtree() // use default node capacity
 

--- a/src/main/scala/com/socrata/geospace/regioncache/SpatialRegionCache.scala
+++ b/src/main/scala/com/socrata/geospace/regioncache/SpatialRegionCache.scala
@@ -3,7 +3,7 @@ package com.socrata.geospace.regioncache
 import com.rojoma.json.ast.JString
 import com.typesafe.config.Config
 import com.socrata.geospace.client.GeoToSoda2Converter
-import com.socrata.geospace.regioncache.SpatialIndex.Entry
+import com.socrata.geospace.regioncache.SpatialIndex.GeoEntry
 import com.socrata.soda.external.SodaFountainClient
 import com.socrata.thirdparty.geojson.FeatureJson
 import org.geoscript.feature._
@@ -35,7 +35,7 @@ class SpatialRegionCache(config: Config) extends MemoryManagingRegionCache[Spati
     var i = 0
     val entries = features.flatMap { case FeatureJson(properties, geometry, _) =>
       val entryOpt = properties.get(GeoToSoda2Converter.FeatureIdColName).
-        collect { case JString(id) => Entry(geometry, id.toInt) }
+        collect { case JString(id) => GeoEntry.compact(geometry, id.toInt) }
       if (!entryOpt.isDefined) logger.warn("dataset feature with missing feature ID property")
       i += 1
       if (i % 1000 == 0) depressurize()

--- a/src/test/scala/com/socrata/geospace/regioncache/SpatialIndexSpec.scala
+++ b/src/test/scala/com/socrata/geospace/regioncache/SpatialIndexSpec.scala
@@ -4,11 +4,11 @@ import org.scalatest.{FunSpec, ShouldMatchers}
 import org.geoscript.geometry.builder
 
 class SpatialIndexSpec extends FunSpec with ShouldMatchers {
-  import SpatialIndex.Entry
+  import SpatialIndex.{Entry, GeoEntry}
 
   val poly1 = builder.Polygon(Seq((10, 10), (10, 20), (20, 20), (20, 10), (10, 10)), Nil)
   val poly2 = builder.Polygon(Seq((16, 6),  (16, 16), (26, 16), (26, 6),  (16, 6)), Nil)
-  val index = new SpatialIndex(Seq(Entry(poly1, "1"), Entry(poly2, "2")))
+  val index = new SpatialIndex(Seq(GeoEntry(poly1, "1"), GeoEntry(poly2, "2")))
 
   describe("SpatialIndex.firstContains") {
     it("should not match a point outside of any geometry") {
@@ -16,14 +16,14 @@ class SpatialIndexSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should match a point in only one geometry") {
-      index.firstContains(builder.Point(18, 18)) should equal (Some(Entry(poly1, "1")))
-      index.firstContains(builder.Point(18, 8)) should equal (Some(Entry(poly2, "2")))
+      index.firstContains(builder.Point(18, 18)).get.item should equal ("1")
+      index.firstContains(builder.Point(18, 8)).get.item should equal ("2")
     }
 
     it("should match a point on a polygon boundary") {
       // NOTE: Specifically match on a geometry's boundary.  This is important because of the
       // many possible JTS spatial operators and their subtle differences
-      index.firstContains(builder.Point(18, 20)) should equal (Some(Entry(poly1, "1")))
+      index.firstContains(builder.Point(18, 20)).get.item should equal ("1")
     }
 
     it("should find one of two geometries a point is in") {
@@ -37,14 +37,14 @@ class SpatialIndexSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should match a point in only one geometry") {
-      index.whatContains(builder.Point(18, 18)) should equal (Seq(Entry(poly1, "1")))
-      index.whatContains(builder.Point(18, 8)) should equal (Seq(Entry(poly2, "2")))
+      index.whatContains(builder.Point(18, 18)).map(_.item) should equal (Seq("1"))
+      index.whatContains(builder.Point(18, 8)).map(_.item) should equal (Seq("2"))
     }
 
     it("should find one of two geometries a point is in") {
       val matches = index.whatContains(builder.Point(18, 11))
       matches should have length (2)
-      matches.toSet should equal (Set(Entry(poly1, "1"), Entry(poly2, "2")))
+      matches.toSet.map { x: Entry[String] => x.item } should equal (Set("1", "2"))
     }
   }
 }

--- a/src/test/scala/com/socrata/geospace/regioncache/SpatialIndexSpec.scala
+++ b/src/test/scala/com/socrata/geospace/regioncache/SpatialIndexSpec.scala
@@ -1,9 +1,9 @@
 package com.socrata.geospace.regioncache
 
-import org.scalatest.{FunSpec, ShouldMatchers}
+import org.scalatest.{FunSpec, OptionValues, ShouldMatchers}
 import org.geoscript.geometry.builder
 
-class SpatialIndexSpec extends FunSpec with ShouldMatchers {
+class SpatialIndexSpec extends FunSpec with ShouldMatchers with OptionValues {
   import SpatialIndex.{Entry, GeoEntry}
 
   val poly1 = builder.Polygon(Seq((10, 10), (10, 20), (20, 20), (20, 10), (10, 10)), Nil)
@@ -16,14 +16,14 @@ class SpatialIndexSpec extends FunSpec with ShouldMatchers {
     }
 
     it("should match a point in only one geometry") {
-      index.firstContains(builder.Point(18, 18)).get.item should equal ("1")
-      index.firstContains(builder.Point(18, 8)).get.item should equal ("2")
+      index.firstContains(builder.Point(18, 18)).value.item should equal ("1")
+      index.firstContains(builder.Point(18, 8)).value.item should equal ("2")
     }
 
     it("should match a point on a polygon boundary") {
       // NOTE: Specifically match on a geometry's boundary.  This is important because of the
       // many possible JTS spatial operators and their subtle differences
-      index.firstContains(builder.Point(18, 20)).get.item should equal ("1")
+      index.firstContains(builder.Point(18, 20)).value.item should equal ("1")
     }
 
     it("should find one of two geometries a point is in") {


### PR DESCRIPTION
- Use `PackedCoordinateSequence` to efficiently store coordinates, up to 60% less memory usage.  Soft reference for on-demand unpacking to faster form.
- Use `PreparedGeometry` for 10x speedup in actual geo-region-coding operation